### PR TITLE
Fix mixed content issue for TTS audio files

### DIFF
--- a/backend/tts_client.py
+++ b/backend/tts_client.py
@@ -18,6 +18,8 @@ class TTSClient:
             base_url: Base URL of the TTS microservice (e.g., "http://localhost:9003")
         """
         self.base_url = base_url or os.getenv("TTS_SERVICE_URL")
+        self.proxy_domain = os.getenv("PROXY_DOMAIN", "https://demo.thetatechnolabs.com")
+        self.proxy_base_path = os.getenv("ROOT_PATH", "/intelligent-triage")
         
     def text_to_speech(self, text: str, voice: str = "female") -> Optional[str]:
         """
@@ -51,7 +53,20 @@ class TTSClient:
                 
                 if audio_url:
                     logger.info(f"TTS audio URL received: {audio_url}")
-                    return audio_url
+                    # Transform HTTP URL to HTTPS proxy URL
+                    # Example: http://106.201.228.100:9003/static/audio/file.wav
+                    # becomes: https://demo.thetatechnolabs.com/intelligent-triage/static/audio/file.wav
+                    if audio_url.startswith("http://106.201.228.100:9003/static/"):
+                        # Extract the path after /static/
+                        static_path = audio_url.replace("http://106.201.228.100:9003/static/", "")
+                        # Build the proxy URL
+                        proxy_url = f"{self.proxy_domain}{self.proxy_base_path}/static/{static_path}"
+                        logger.info(f"Transformed URL: {audio_url} -> {proxy_url}")
+                        return proxy_url
+                    else:
+                        # Return original URL if it doesn't match expected pattern
+                        logger.warning(f"Unexpected TTS URL format: {audio_url}")
+                        return audio_url
                 else:
                     logger.error(f"No audio_url in TTS response: {response_data}")
                     return None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       - TTS_SERVICE_URL=http://106.201.228.100:9003
       - ROOT_PATH=/intelligent-triage
+      - PROXY_DOMAIN=https://demo.thetatechnolabs.com
     volumes:
       - ./backend/responses:/app/responses
       - ./backend/uploads:/app/uploads

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -47,6 +47,24 @@ http {
             return 301 /intelligent-triage;
         }
 
+        # Proxy TTS service static files - with base path
+        location /intelligent-triage/static/ {
+            proxy_pass http://106.201.228.100:9003/static/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # CORS headers for audio files
+            add_header Access-Control-Allow-Origin *;
+            add_header Access-Control-Allow-Methods "GET, OPTIONS";
+            add_header Access-Control-Allow-Headers "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization";
+            
+            # Cache audio files
+            expires 1h;
+            add_header Cache-Control "public";
+        }
+
         # Proxy API requests to backend - with base path
         location ~ ^/intelligent-triage/(chat|triage|tts|docs|openapi) {
             proxy_pass http://backend:9001;
@@ -72,6 +90,24 @@ http {
                 add_header Content-Length 0;
                 return 204;
             }
+        }
+
+        # Proxy TTS service static files - direct access
+        location /static/ {
+            proxy_pass http://106.201.228.100:9003/static/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # CORS headers for audio files
+            add_header Access-Control-Allow-Origin *;
+            add_header Access-Control-Allow-Methods "GET, OPTIONS";
+            add_header Access-Control-Allow-Headers "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization";
+            
+            # Cache audio files
+            expires 1h;
+            add_header Cache-Control "public";
         }
 
         # Proxy API requests to backend - direct access (without base path)

--- a/server-nginx-intelligent-triage.conf
+++ b/server-nginx-intelligent-triage.conf
@@ -21,6 +21,24 @@ server {
         return 301 /intelligent-triage/;
     }
 
+    # Proxy TTS service static files
+    location /intelligent-triage/static/ {
+        proxy_pass http://106.201.228.100:9003/static/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # CORS headers for audio files
+        add_header Access-Control-Allow-Origin *;
+        add_header Access-Control-Allow-Methods "GET, OPTIONS";
+        add_header Access-Control-Allow-Headers "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization";
+        
+        # Cache audio files
+        expires 1h;
+        add_header Cache-Control "public";
+    }
+
     # Backend API - FastAPI application
     location ~ ^/intelligent-triage/(chat|triage|tts|docs|openapi) {
         proxy_pass http://localhost:9001;


### PR DESCRIPTION
- Add nginx proxy for TTS static files at /intelligent-triage/static/
- Update TTS client to transform HTTP URLs to HTTPS proxy URLs
- Configure both frontend nginx.conf and server nginx config
- Add PROXY_DOMAIN environment variable to docker-compose
- This resolves the mixed content error where HTTPS pages couldn't load HTTP audio files